### PR TITLE
fixed removing precept bug

### DIFF
--- a/recalpp/static/js/calendar.js
+++ b/recalpp/static/js/calendar.js
@@ -32,13 +32,13 @@ $(document).ready(function () {
       const unsaturatedDarkColor = events[courseIndex].textColor;
       const saturatedLightColor = getDesaturatedColor(
         events[courseIndex].color,
-        -70
+        -80
       );
       const saturatedDarkColor = darkenColor(saturatedLightColor);
 
       if (events[courseIndex].enrolled) {
         events[courseIndex].enrolled = false;
-        // Determines of the event is a precept: P, class: C, etc.
+        // Determines if the event is a precept: P, class: C, etc.
         const meetingIdentifier = events[courseIndex].section.charAt(0);
         // Changes all relevant sections enrolled false and color to default
         for (let i = 0; i < numMeetingsForCourse; i++) {
@@ -64,7 +64,7 @@ $(document).ready(function () {
         }
       } else {
         events[courseIndex].enrolled = true;
-        // Determines of the event is a precept: P, class: C, etc.
+        // Determines if the event is a precept: P, class: C, etc.
         const meetingIdentifier = events[courseIndex].section.charAt(0);
         // Change all relevant sections to enrolled true and resaturate the event
         for (let i = 0; i < numMeetingsForCourse; i++) {
@@ -82,7 +82,8 @@ $(document).ready(function () {
           }
           if (
             meetingIdentifier === events[i].section.charAt(0) &&
-            !events[i].enrolled
+            !events[i].enrolled &&
+            events[i].section !== events[courseIndex].section
           ) {
             calendar_event_object.view.calendar
               .getEventById(events[i].id)
@@ -90,7 +91,6 @@ $(document).ready(function () {
           }
         }
       }
-      console.log(events);
     },
   });
   calendar.render();

--- a/recalpp/static/js/calendar_functionality.js
+++ b/recalpp/static/js/calendar_functionality.js
@@ -72,7 +72,7 @@ async function addCourseToCalendar(course) {
     return baseDate.toISOString().slice(0, 10);
   }
 
-  const color = getDesaturatedColor(getRandomLightColor(), 70);
+  const color = getDesaturatedColor(getRandomLightColor(), 80);
   const darkColor = darkenColor(color);
 
   meetings.forEach((meet, index) => {
@@ -107,9 +107,14 @@ async function addCourseToCalendar(course) {
  */
 function removeCourseFromCalendar(guid) {
   const events = User.getCourseMeetingsByGuid(guid);
+  console.log(guid);
+  console.log(events);
   User.removeCourseMeeting(guid);
   events.forEach((event) => {
     const calendarEvent = calendar.getEventById(event.id);
-    calendarEvent.remove();
+    if (calendarEvent !== null) {
+      console.log(event.id);
+      calendarEvent.remove();
+    }
   });
 }


### PR DESCRIPTION
Originally, if you enrolled in a meeting with multiple sections (i.e P01, P02), and you tried to remove a course, it would bug out and the course would stay on the calendar. This is now fixed.